### PR TITLE
feat(sequencepool): change the common tracker quorum size

### DIFF
--- a/sequencepool/command_tracker.go
+++ b/sequencepool/command_tracker.go
@@ -19,7 +19,7 @@ type commandTracker struct {
 }
 
 func NewCommandTracker(n int) *commandTracker {
-	return &commandTracker{quorum: types.CalculateOneQuorum(n), proposedCmd: make(map[string]int)}
+	return &commandTracker{quorum: types.CalculateQuorum(n), proposedCmd: make(map[string]int)}
 }
 
 func (ct *commandTracker) Add(digest string) {

--- a/test/phalanx_bft_test.go
+++ b/test/phalanx_bft_test.go
@@ -52,7 +52,7 @@ func TestPhalanx(t *testing.T) {
 	}
 	go cluster(sendC, bftCs, closeC)
 
-	count := 20000
+	count := 2000
 	for i:=0; i<count; i++ {
 		go commandSender(phx)
 	}


### PR DESCRIPTION
the quorum size in common tracker should be equal to that in executor as it is used to skip duplicated logs for execution